### PR TITLE
Fix NoMethodError when used outside of Rails/Bundler

### DIFF
--- a/lib/minitest/snapshots/test_extensions.rb
+++ b/lib/minitest/snapshots/test_extensions.rb
@@ -6,7 +6,7 @@ module Minitest
       def before_setup
         super
         @snapshot_assertion_counter = 0
-        @snapshot_dir ||= if defined?(Rails)
+        @snapshot_dir ||= if defined?(Rails) && Rails.respond_to?(:root)
                             Rails.root.join("test", "snapshots").to_s
                           elsif Dir.exist?("test")
                             File.expand_path("test/snapshots")


### PR DESCRIPTION
This patch fixes the following error when minitest is used outside of a Rails project:

> NoMethodError: undefined method 'root' for Rails:Module

This happens because of how minitest plugins are loaded.

When minitest is run outside of a Rails/Bundler environment, it will scan through *all* gems in the Ruby environment. For all gems that includes minitest plugins, minitest will eagerly load all those plugins.

This includes the plugin in minitest-snapshots, but it also includes a minitest plugin that is packaged inside the railties gem if the user has railties installed in their Ruby environment.

When the railties minitest plugin is loaded, a side effect is that a `Rails` module gets defined. Rails itself does not get loaded; only the minitest plugin. Thus the `Rails` module is empty.

Trace:

1. Minitest detects and loads this minitest plugin from inside the railties gem: [minitest/rails_plugin.rb](https://github.com/rails/rails/blob/v7.0.5.1/railties/lib/minitest/rails_plugin.rb)
2. Which in turn loads [rails/test_unit/reporter](https://github.com/rails/rails/blob/v7.0.5.1/railties/lib/minitest/rails_plugin.rb#L4)
3. Which then declares the `Rails` module: [reporter.rb:6](https://github.com/rails/rails/blob/v7.0.5.1/railties/lib/rails/test_unit/reporter.rb#L6)

Later when minitest-snapshots tries to call `Rails.root`, this error occurs:

> NoMethodError: undefined method 'root' for Rails:Module

The fix provided by this patch is to check that `root` is defined before calling it.

```ruby
if defined?(Rails) && Rails.respond_to?(:root)
```

This works around the edge case where the railties minitest plugin has been loaded but the Rails framework itself has not.